### PR TITLE
Allow appending multiple items to a menu GH-68

### DIFF
--- a/consolemenu/console_menu.py
+++ b/consolemenu/console_menu.py
@@ -105,17 +105,20 @@ class ConsoleMenu(object):
         else:
             return None
 
-    def append_item(self, item):
+    def append_item(self, *items):
         """
-        Add an item to the end of the menu before the exit item.
+        Add one or more items to the end of the menu before the exit item.
 
         Args:
-            item (MenuItem): The item to be added.
+            items (list[MenuItem]): The item to be added.
 
         """
+        if len(items) == 0:
+            return
         did_remove = self.remove_exit()
-        item.menu = self
-        self.items.append(item)
+        for item in items:
+            item.menu = self
+            self.items.append(item)
         if did_remove:
             self.add_exit()
 

--- a/test/test_console_menu.py
+++ b/test/test_console_menu.py
@@ -108,6 +108,18 @@ class TestConsoleMenu(BaseTestCase):
         menu2.join(timeout=5)
         menu1.join(timeout=5)
 
+    def test_append_menu_items(self):
+        menu = ConsoleMenu("menu1", "test_currently_active_menu_1")
+        item1 = MenuItem(text='itemText', menu=menu)
+        item2 = MenuItem(text='itemText2', menu=menu)
+        item3 = MenuItem(text='itemText3', menu=menu)
+        menu.append_item()
+        menu.append_item(item1)
+        menu.append_item(item2, item3)
+        self.assertIn(item1, menu.items)
+        self.assertIn(item2, menu.items)
+        self.assertIn(item3, menu.items)
+
     def test_remove_menu_item(self):
         menu = ConsoleMenu("menu1", "test_currently_active_menu_1")
         item1 = MenuItem(text='itemText', menu=menu)


### PR DESCRIPTION
Modify `ConsoleMenu.append_item()` to accept any number of items which are to be appended to the menu, enabling users to write cleaner menu setup code. Also add a test for appending zero, one, and more than one items.